### PR TITLE
OverTheMidnight v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,62 @@ Or install it yourself as:
 ## Usage
 
 ``` ruby
+require "over_the_midnight"
+
 date = Date.new(2016, 8, 13)
 
+#--------------------#
 # version 0.1.x
-require "over_the_midnight"
-otm = OverTheMidnight.new(date, "25:00")
-otm.to_time.strftime("%Y/%m/%d %H:%M")
+# otm = OverTheMidnight.new(date, "25:00")
+# otm.to_time.strftime("%Y/%m/%d %H:%M")
 #=> "2016/08/14 01:00"
 
-otm = OverTheMidnight.new(date, 30.5)
-otm.to_time.strftime("%Y/%m/%d %H:%M")
+# otm = OverTheMidnight.new(date, 30.5)
+# otm.to_time.strftime("%Y/%m/%d %H:%M")
 #=> "2016/08/14 06:30"
+
+#--------------------#
+# version 0.2.x
+
+otm = OverTheMidnight.create(date, "25:00")
+
+otm.class
+#=> OverTheMidnight::Time
+
+otm.date.to_s
+#=> "2016/08/13"
+
+otm.time.class
+#=> Time
+
+otm.time.strftime("%Y/%m/%d %H:%M")
+#=> "2016/08/14 01:00"
+
+otm.to_s
+#=> "2016/08/13 25:00"
+
+#created with Numeric
+otm = OverTheMidnight.create(date, 30.5)
+
+otm.time.strftime("%Y/%m/%d %H:%M")
+#=> "2016/08/14 06:30"
+
+otm.to_s
+#=> "2016/08/13 30:30"
+
+
+# created with Time
+time = Time.local((date + 1).year, (date + 1).month, (date + 1).day, 10, 45)
+
+otm = OvertTheMidnight.create(date, time)
+
+otm.time.strftime("%Y/%m/%d %H:%M")
+#=> "2016/08/14 10:45"
+# NOT "2016/08/13 10:45" 
+
+otm.to_s
+#=> "2016/08/13 34:45"
+# NOT "2016/08/14 10:45" 
 
 ```
 

--- a/lib/over_the_midnight.rb
+++ b/lib/over_the_midnight.rb
@@ -4,7 +4,7 @@ module OverTheMidnight
   LIB = File.expand_path(File.dirname(__FILE__))
   ROOT = File.dirname(OverTheMidnight::LIB)
   
-  def self.new(*args)
+  def self.create(*args)
     self::Time.new(*args)
   end
 end

--- a/lib/over_the_midnight/time.rb
+++ b/lib/over_the_midnight/time.rb
@@ -1,6 +1,9 @@
 require "date"
 
 class OverTheMidnight::Time
+  DATE_FORMAT = "%Y/%m/%d"
+  TIME_FORMAT = "%H:%M"
+  
   attr_reader :date
   
   def initialize(date, time)
@@ -9,8 +12,19 @@ class OverTheMidnight::Time
     @raw_time = time
   end
   
-  def to_time
-    parse
+  def hour
+    time.hour + ((time.to_date - date).to_i * 24)
+  end
+  
+  def time
+    @time ||= parse
+  end
+  
+  def to_s
+    date_format = date.strftime(DATE_FORMAT)
+    format = [date_format, TIME_FORMAT].join(" ")
+    format.gsub!(/\%H/, "#{hour}")
+    time.strftime(format)
   end
   
   private
@@ -21,6 +35,8 @@ class OverTheMidnight::Time
       parse_string
     when Numeric
       parse_numeric
+    when Time
+      parse_time
     else
       raise "invalid time"
     end
@@ -41,5 +57,9 @@ class OverTheMidnight::Time
     min   = ((@raw_time % 1.0) * 60)
     _date = @date + (@raw_time / 24)
     Time.new(_date.year, _date.month, _date.day, hour, min)
+  end
+  
+  def parse_time
+    @raw_time
   end
 end

--- a/lib/over_the_midnight/version.rb
+++ b/lib/over_the_midnight/version.rb
@@ -1,3 +1,3 @@
 module OverTheMidnight
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/over_the_midnight/time_spec.rb
+++ b/spec/over_the_midnight/time_spec.rb
@@ -1,21 +1,76 @@
 require 'spec_helper'
 
 describe OverTheMidnight::Time do
-  describe ".new" do
-    subject { described_class.new(date, time) }
-    let(:date) { Date.today }
+  let(:obj) { described_class.new(date, time) }
+  let(:today) { Date.today }
+  let(:date) { today }
+  let(:time) { "9:00" }
 
+  describe ".new" do
+    subject { obj }
+    
     context "with String time" do
       let(:time) { "25:00" }
       let(:next_date) { date + 1 }
       
-      it { expect(subject.to_time).to eq Time.new(next_date.year, next_date.month, next_date.day, 1, 0) }
+      it { expect(subject.time).to eq Time.new(next_date.year, next_date.month, next_date.day, 1, 0) }
     end
     
     context "with Numeric time" do
       let(:time) { 30.5 }
       let(:next_date) { date + 1 }
-      it { expect(subject.to_time).to eq Time.new(next_date.year, next_date.month, next_date.day, 6, 30) }
+      it { expect(subject.time).to eq Time.new(next_date.year, next_date.month, next_date.day, 6, 30) }
+    end
+    
+    context "with Time" do
+      let(:time)  { Time.local(date.year, date.month, date.day, hour, min) }
+      let(:hour)  { 10 }
+      let(:min)   { 45 }
+      it { expect(subject.time.day).to eq time.day }
+      
+      context "with not same date" do
+        let(:time_date) { today + 1 }
+        let(:time) { Time.local(time_date.year, time_date.month, time_date.day, hour, min) }
+        
+        it { expect(subject.time.day).to      eq time.day }
+        it { expect(subject.time.day).not_to  eq date.day }
+      end
+    end
+  end
+  
+  describe "#date" do
+    subject { obj.date }
+    it { is_expected.to be_kind_of(Date) }
+    it { is_expected.to eq date }
+  end
+  
+  describe "#time" do
+    subject { obj.time }
+    it { is_expected.to be_kind_of(Time) }
+  end
+  
+  describe "#hour" do
+    subject { obj.hour }
+    let(:time) { "25:00" }
+    
+    it { is_expected.to eq 25 }
+  end
+  
+  describe "#to_s" do
+    subject { obj.to_s }
+    
+    context "with valid date, time" do
+      it { is_expected.to match /[0-9]{4}\/[0-9]{2}\/[0-9]{2}\s{1}[0-9]+\:[0-9]{2}/ }
+    end
+    
+    context "with Time next date" do
+      let(:diff) { 1 }
+      let(:tomorrow) { date + diff }
+      let(:time)  { Time.local(tomorrow.year, tomorrow.month, tomorrow.day, hour, min) }
+      let(:hour)  { 10 }
+      let(:min)   { 45 }
+      it { is_expected.to match /#{date.strftime("%d")}\s{1}/ }
+      it { is_expected.to match /#{hour + (diff * 24)}\:/ }
     end
   end
 end

--- a/spec/over_the_midnight_spec.rb
+++ b/spec/over_the_midnight_spec.rb
@@ -5,8 +5,8 @@ describe OverTheMidnight do
     expect(OverTheMidnight::VERSION).not_to be nil
   end
 
-  describe ".new" do
-    subject { described_class.new(date, time) }
+  describe ".create" do
+    subject { described_class.create(date, time) }
     let(:date) { Date.today }
     let(:time) { "25:00" }
     it { is_expected.to be_kind_of(described_class::Time) }


### PR DESCRIPTION
OverTheMidnight
- .create instead of .new

OverTheMidnight::Time
- #initialize allows Time object as 'time'
- #hour
- #time instead of #to_time
- #to_s
